### PR TITLE
Better sessionLog filters

### DIFF
--- a/src/Model/RequestLog.php
+++ b/src/Model/RequestLog.php
@@ -148,6 +148,7 @@ class RequestLog extends DataObject
                 'IPAddress' => $ipAddress,
                 'LastAccessed' => $requestLog->Created,
                 'UserAgent' => $userAgent,
+                'NumberOfRequests' => $sessionLog->NumberOfRequests + 1,
             ];
 
             $sessionLog->update($sessionData);


### PR DESCRIPTION
SessionLog to keep a running total of requests, as requests data may be truncated for privacy reasons. Add search to the SessionLog cms model admin  for request url, request type, and number of requests.